### PR TITLE
✨ Add Lua TextMate scopes to defaults (fixes #8)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.5.0] - 2026-06-22
+
+### Added
+
+- Default TextMate scopes for Lua (`variable.other.lua`, `variable.parameter.function.lua`, `support.function.lua`, `support.function.library.lua`, `entity.other.attribute.lua`), so Lua locals, function parameters, built-ins, and namespaced stdlib calls are semantically colored out of the box. Language keywords (`if`, `then`, `end`, `local`, `function`, etc.) keep their theme color since the root `source.lua` scope is intentionally excluded. Respects the `hasDefaultTextMateTokenScopes` setting. Fixes [#8](https://github.com/Sawtaytoes/vscode-colormate/issues/8).
+
 ## [4.4.0] - 2026-06-04
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-colormate",
   "displayName": "ColorMate: Semantic Highlighter",
   "description": "ColorMate colors all similarly named variables the same, so you can quickly and easily skim your code by reading colors instead of text. The hashing algorithm is modeled after the same amazing CRC8 hasher used by Colorcoder for Sublime Text.",
-  "version": "4.4.0",
+  "version": "4.5.0",
   "license": "MIT",
   "author": "Kevin Ghadyani",
   "publisher": "KevinGhadyani",
@@ -175,7 +175,7 @@
         "colormate.hasDefaultTextMateTokenScopes": {
           "type": "boolean",
           "default": true,
-          "markdownDescription": "ColorMate comes with its own TextMate token scopes for JavaScript, TypeScript, HTML, JSON, dotenv, and shell. If you'd like to disable those defaults, disable this setting.\n\nThese aren't the same as the semantic scopes. Those you can override with a separate setting. All this does is disable the special TextMate token scopes (and their accompanying default exclusions) that were defined to make these languages fully render with semantic highlighting in areas not covered by semantic tokens."
+          "markdownDescription": "ColorMate comes with its own TextMate token scopes for JavaScript, TypeScript, HTML, JSON, dotenv, shell, and Lua. If you'd like to disable those defaults, disable this setting.\n\nThese aren't the same as the semantic scopes. Those you can override with a separate setting. All this does is disable the special TextMate token scopes (and their accompanying default exclusions) that were defined to make these languages fully render with semantic highlighting in areas not covered by semantic tokens."
         },
         "colormate.textMateTokenScopes": {
           "type": "array",

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -98,13 +98,18 @@ export const getConfiguredTextMateTokenScopes: (
           "entity.name.section.markdown",
           "entity.name.tag",
           "entity.other.attribute-name",
+          "entity.other.attribute.lua",
+          "support.function.library.lua",
+          "support.function.lua",
           "support.type.property-name.json",
           "variable.key.dotenv",
           "variable.other.assignment.shell",
+          "variable.other.lua",
           "variable.other.normal.shell",
           "variable.other.property",
           "variable.other.readwrite.ts",
           "variable.other.readwrite.alias",
+          "variable.parameter.function.lua",
         ]
         : []
       ),


### PR DESCRIPTION
Adds Lua language support to ColorMate's default TextMate token scopes so Lua files get rainbow coloring out of the box, with no user config required.

## What

Adds five narrow, language-suffixed Lua scopes to the default `textMateTokenScopes` list in `src/configuration.ts`:

- `variable.other.lua` — local variables
- `variable.parameter.function.lua` — function parameters
- `support.function.lua` — global built-ins (`tostring`, `ipairs`, …)
- `support.function.library.lua` — namespaced stdlib functions
- `entity.other.attribute.lua` — namespace identifiers

The root `source.lua` scope is **intentionally omitted** so Lua keywords (`if`, `then`, `end`, `local`, `function`, `and`, `or`, …) keep their theme color, per the issue's warning.

Also:
- Bumps version `4.4.0` → `4.5.0` (minor, matching the `4.3.0` dotenv/shell default-scope release pattern).
- Updates the `hasDefaultTextMateTokenScopes` setting description to mention Lua.
- Adds a `[4.5.0]` CHANGELOG entry.

## Verification

- `yarn compile` ✅
- `yarn lint` ✅

Fixes #8