### PR TITLE
👷 Add GitHub Actions workflow to build the VSIX

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,61 @@
+name: Build VSIX
+
+on:
+  push:
+    branches:
+      - master
+    tags:
+      - 'v*'
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: Build & package
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+
+      - name: Enable Corepack
+        run: corepack enable
+
+      - name: Install dependencies
+        run: yarn install --immutable
+
+      - name: Package VSIX
+        # Runs the `vscode:prepublish` hook (clean + check-types + lint + production build).
+        run: npx --yes @vscode/vsce package --no-yarn
+
+      - name: Upload VSIX artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: vscode-colormate-vsix
+          path: '*.vsix'
+          if-no-files-found: error
+
+  publish:
+    name: Publish to Marketplace
+    needs: build
+    if: startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+
+      - name: Enable Corepack
+        run: corepack enable
+
+      - name: Install dependencies
+        run: yarn install --immutable
+
+      - name: Publish
+        env:
+          VSCE_PAT: ${{ secrets.VSCE_PAT }}
+        run: npx --yes @vscode/vsce publish --no-yarn


### PR DESCRIPTION
Adds a GitHub Actions workflow so the extension is built and packaged in CI.

## What

- **`build` job** — runs on every push to `master`, on PRs, and via manual dispatch. Installs deps (Yarn 4 / Corepack, Node 24), then `vsce package` (which runs the `vscode:prepublish` hook: clean + check-types + lint + production esbuild) and uploads the resulting `.vsix` as a build artifact.
- **`publish` job** — runs only on `v*` tag pushes. Publishes to the Marketplace via `vsce publish` using a `VSCE_PAT` repo secret.

## Follow-up to enable auto-publish

The publish job is inert until a **`VSCE_PAT`** secret is added (Settings → Secrets and variables → Actions). After that, pushing a `vX.Y.Z` tag publishes automatically. The build/artifact half works immediately with no secret.