### PR TITLE
👷 Bump CI actions to latest + add .env scaffolding

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,6 @@
+# Personal Access Token for publishing to the VS Code Marketplace with `vsce`.
+# Generate one at https://aka.ms/vscodepat (Azure DevOps) for the
+# KevinGhadyani publisher with the "Marketplace > Manage" scope.
+# Copy this file to `.env` and fill in the value (the `.env` file is gitignored).
+# `vsce` automatically reads VSCE_PAT from the environment when publishing.
+VSCE_PAT=

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,9 +14,9 @@ jobs:
     name: Build & package
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 24
 
@@ -31,7 +31,7 @@ jobs:
         run: npx --yes @vscode/vsce package --no-yarn
 
       - name: Upload VSIX artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: vscode-colormate-vsix
           path: '*.vsix'
@@ -43,9 +43,9 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 24
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+.env
+.env.*
+!.env.example
 .tsbuildinfo
 .vscode-test/
 .yarn/install-state.gz


### PR DESCRIPTION
## What

- Bumps GitHub Actions to current majors: `checkout@v4`→`@v7`, `setup-node@v4`→`@v6`, `upload-artifact@v4`→`@v7`. Clears the Node 20 deprecation warning from the first CI run.
- Adds a committed `.env.example` documenting the `VSCE_PAT` used by `vsce` for publishing, and gitignores `.env` (while keeping `.env.example` tracked).