### PR TITLE
👷 Drop Marketplace publish job; build VSIX only

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,26 +36,3 @@ jobs:
           name: vscode-colormate-vsix
           path: '*.vsix'
           if-no-files-found: error
-
-  publish:
-    name: Publish to Marketplace
-    needs: build
-    if: startsWith(github.ref, 'refs/tags/v')
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v7
-
-      - uses: actions/setup-node@v6
-        with:
-          node-version: 24
-
-      - name: Enable Corepack
-        run: corepack enable
-
-      - name: Install dependencies
-        run: yarn install --immutable
-
-      - name: Publish
-        env:
-          VSCE_PAT: ${{ secrets.VSCE_PAT }}
-        run: npx --yes @vscode/vsce publish --no-yarn


### PR DESCRIPTION
Per request: keep CI building the VSIX, but never store a Marketplace PAT in the cloud. Publishing stays manual.

## What

- Removes the tag-gated `publish` job (and its `VSCE_PAT` secret usage) from `.github/workflows/build.yml`.
- CI now only builds + uploads the `.vsix` artifact (no secrets required).
- Keeps the `v*` tag trigger so tagging a release still produces a downloadable `.vsix` to upload manually.