### PR TITLE
👷 Attach built VSIX to GitHub Releases on version tags

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,3 +36,28 @@ jobs:
           name: vscode-colormate-vsix
           path: '*.vsix'
           if-no-files-found: error
+
+  release:
+    name: Attach VSIX to GitHub Release
+    needs: build
+    # Only on version tags (e.g. v4.5.0). Uses the automatic GITHUB_TOKEN —
+    # no external/Marketplace token. Publishing to the Marketplace stays manual.
+    if: startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Download VSIX artifact
+        uses: actions/download-artifact@v8
+        with:
+          name: vscode-colormate-vsix
+
+      - name: Create or update the GitHub Release and attach the VSIX
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          if gh release view "$GITHUB_REF_NAME" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+            gh release upload "$GITHUB_REF_NAME" *.vsix --repo "$GITHUB_REPOSITORY" --clobber
+          else
+            gh release create "$GITHUB_REF_NAME" *.vsix --repo "$GITHUB_REPOSITORY" --title "$GITHUB_REF_NAME" --generate-notes
+          fi


### PR DESCRIPTION
Builds the VSIX in CI and uploads it to **GitHub Releases** (not the Marketplace), using the automatic `GITHUB_TOKEN`. No external/Marketplace token is ever stored in the cloud — Marketplace publishing stays manual.

## What

- Adds a `release` job that runs only on `v*` tag pushes.
- It downloads the `.vsix` built by the `build` job and creates (or updates, via `--clobber`) the GitHub Release for that tag with the `.vsix` attached, auto-generating release notes.
- Auth is `GITHUB_TOKEN` with `contents: write` — nothing external.

## How to cut a release

```
# bump version + changelog, commit, then:
git tag v4.5.1
git push origin v4.5.1
```

CI builds the `.vsix` and attaches it to the `v4.5.1` GitHub Release. Download it there and upload to the Marketplace manually when ready.